### PR TITLE
Register capabilities during preinit

### DIFF
--- a/src/main/java/net/crazysnailboy/mods/enchantingtable/proxy/CommonProxy.java
+++ b/src/main/java/net/crazysnailboy/mods/enchantingtable/proxy/CommonProxy.java
@@ -17,11 +17,11 @@ public class CommonProxy
 	public void preInit()
 	{
 		registerTileEntities();
+		registerCapabilities();
 	}
 
 	public void init()
 	{
-		registerCapabilities();
 		registerGuiHandler();
 	}
 


### PR DESCRIPTION
Mods should be able to use items, blocks, and entities during mod init, but are currently unable to do so because entities depend on capabilities, resulting in a null pointer exception from EnchantingTable since the LAPIS_HANDLER_CAPABILITY wasn't injected yet (because it wasn't registered).

This fixes this issue and its three duplicates: https://github.com/crazysnailboy/EnchantingTable/issues/10 https://github.com/crazysnailboy/EnchantingTable/issues/8 https://github.com/crazysnailboy/EnchantingTable/issues/7 https://github.com/crazysnailboy/EnchantingTable/issues/6